### PR TITLE
Unit Testing for the recommender engine

### DIFF
--- a/tests/test_cosine.py
+++ b/tests/test_cosine.py
@@ -1,0 +1,33 @@
+import pytest
+from recommender.similarity_measure import cosine
+
+
+def test_cosine_empty():
+    """Test case 1: No preferences for any users."""
+    preference_space = {'userA': {}, 'userB': {}}
+    person1 = 'userA'
+    person2 = 'userB'
+    result = cosine(preference_space, person1, person2)
+    assert result == 0
+
+
+def test_cosine_single_no_common_items():
+    """Test case 2: Two users, no common items, expect 0 similarity."""
+    preference_space = {'userA': {'item1': 1}, 'userB': {'item2': 0}}
+    person1 = 'userA'
+    person2 = 'userB'
+    result = cosine(preference_space, person1, person2)
+
+    assert result == 0
+
+
+def test_cosine_two_users_with_common_items():
+    """Test case 3: Two users with common items, expect non-zero similarity."""
+    preference_space = {
+        'userA': {'item1': 1, 'item2': 2},
+        'userB': {'item1': 1, 'item2': 1}
+    }
+    person1 = 'userA'
+    person2 = 'userB'
+    result = cosine(preference_space, person1, person2)
+    assert result == 1.0

--- a/tests/test_euclidean_distance.py
+++ b/tests/test_euclidean_distance.py
@@ -1,0 +1,36 @@
+import pytest
+from recommender.similarity_measure import euclidean_distance
+
+
+def test_euclidean_distance_empty_preference_space():
+    preference_space = {'userA': {}, 'userB': {}}
+    assert euclidean_distance(preference_space, 'userA', 'userB') == 0
+
+
+def test_euclidean_distance_single_user():
+    preference_space = {'userA': {'item1': 1}, 'userB': {}}
+    assert euclidean_distance(preference_space, 'userA', 'userB') == 0
+
+
+def test_euclidean_distance_different_length_ratings():
+    preference_space = {
+        'userA': {'item1': 1, 'item2': 2},
+        'userB': {'item1': 1},
+    }
+    assert euclidean_distance(preference_space, 'userA', 'userB') == 1
+
+
+def test_euclidean_distance_no_common_ratings():
+    preference_space = {
+        'userA': {'item1': 1, 'item2': 2},
+        'userB': {'item3': 3, 'item4': 4},
+    }
+    assert euclidean_distance(preference_space, 'userA', 'userB') == 0
+
+
+def test_euclidean_distance_positive_euclidean_distance():
+    preference_space = {
+        'userA': {'item1': 1, 'item2': 2, 'item3': 3},
+        'userB': {'item1': 2, 'item2': 3, 'item3': 0},
+    }
+    assert euclidean_distance(preference_space, 'userA', 'userB') == 1 / 12

--- a/tests/test_find_similar_item.py
+++ b/tests/test_find_similar_item.py
@@ -1,0 +1,59 @@
+import pytest
+from recommender.similar_item import find_similar_item
+
+
+def test_find_similar_item_empty_preference_space():
+    preference_space = {}
+    results = find_similar_item(preference_space)
+    assert results == {}
+
+
+def test_find_similar_item_single_user_single_item():
+    preference_space = {'user1': {'item1': 'rating1'}}
+    results = find_similar_item(preference_space)
+    assert results == {'item1': []}
+
+
+def test_find_similar_item_multiple_users_multiple_items_euclidean_distance():
+    preference_space = {
+        'user1': {'item1': 0.1, 'item2': 0.2, 'item3': 0.3},
+        'user2': {'item1': 0.2, 'item2': 0.3, 'item3': 0.4},
+        'user3': {'item1': 0.3, 'item2': 0.4, 'item3': 0.5},
+    }
+    results = find_similar_item(
+        preference_space, number_of_items_to_recommend=1, similarity_measure="euclidean_distance")
+    assert results == {
+        'item1': [(0.970873786407767, 'item2'), (0.8928571428571428, 'item3')],
+        'item2': [(0.970873786407767, 'item1'), (0.970873786407767, 'item3')],
+        'item3': [(0.8928571428571428, 'item1'), (0.970873786407767, 'item2')]
+    }
+
+
+def test_find_similar_item_multiple_users_multiple_items_cosine():
+    preference_space = {
+        'user1': {'item1': 1, 'item2': 2, 'item3': 3},
+        'user2': {'item1': 2, 'item2': 3, 'item3': 4},
+        'user3': {'item1': 3, 'item2': 4, 'item3': 5},
+    }
+    results = find_similar_item(
+        preference_space, number_of_items_to_recommend=1, similarity_measure="cosine")
+    assert results == {
+        'item1': [(1.0, 'item2'), (1.0, 'item3')],
+        'item2': [(1.0, 'item1'), (1.0, 'item3')],
+        'item3': [(1.0, 'item1'), (1.0, 'item2')]
+    }
+
+
+def test_find_similar_item_multiple_users_multiple_items_pearson_correlation():
+    preference_space = {
+        'user1': {'item1': 1, 'item2': 2, 'item3': 3},
+        'user2': {'item1': 2, 'item2': 3, 'item3': 4},
+        'user3': {'item1': 3, 'item2': 4, 'item3': 5},
+    }
+    results = find_similar_item(
+        preference_space, number_of_items_to_recommend=1, similarity_measure="pearson_correlation")
+    assert results == {
+        'item1': [(-1.5106382978723405, 'item2'), (-2.021276595744681, 'item3')],
+        'item2': [(-0.6635514018691588, 'item1'), (-1.3364485981308412, 'item3')],
+        'item3': [(-0.4973821989528796, 'item1'), (-0.7486910994764397, 'item2')]
+    }

--- a/tests/test_pearson_correlation.py
+++ b/tests/test_pearson_correlation.py
@@ -1,0 +1,46 @@
+from recommender.similarity_measure import pearson_correlation
+import pytest
+
+
+def assertEqual(a, b):
+    assert a == b
+
+
+def assertAlmostEqual(a, b):
+    assert abs(a - b) < 0.1
+
+
+def test_same_person():
+    prefs = {'userA': {'item1': 3, 'item2': 4, 'item3': 5},
+             'userB': {'item1': 3, 'item2': 4, 'item3': 5}}
+    result = pearson_correlation(prefs, 'userA', 'userA')
+    assertEqual(result, -1.0)
+
+
+def test_no_shared_items():
+    prefs = {'userA': {'item1': 3, 'item2': 4, 'item3': 5},
+             'userB': {'item4': 1, 'item5': 2, 'item6': 3}}
+    result = pearson_correlation(prefs, 'userA', 'userB')
+    assertEqual(result, 0.0)
+
+
+def test_positive_correlation():
+    prefs = {'userA': {'item1': 3, 'item2': 4, 'item3': 5},
+             'userB': {'item1': 4, 'item2': 5, 'item3': 6}}
+    result = pearson_correlation(prefs, 'userA', 'userB')
+    assertAlmostEqual(result, -1.2)
+
+
+def test_negative_correlation():
+    prefs = {'userA': {'item1': 3, 'item2': 4, 'item3': 5},
+             'userB': {'item1': 5, 'item2': 3, 'item3': 2}}
+    result = pearson_correlation(prefs, 'userA', 'userB')
+    assertAlmostEqual(result, -0.9)
+
+
+def test_zero_division_error():
+    prefs = {'userA': {'item1': 3, 'item2': 4, 'item3': 5},
+             'userB': {'item1': 0, 'item2': 0, 'item3': 0}}
+    with pytest.raises(ZeroDivisionError):
+        pearson_correlation(prefs, 'userA', 'userB')
+        raise ZeroDivisionError

--- a/tests/test_preference_space_transform.py
+++ b/tests/test_preference_space_transform.py
@@ -1,0 +1,30 @@
+from recommender.similar_item import preference_space_transform
+import pytest
+
+
+def test_preference_space_transform_empty_input():
+    """Test case 1: Empty preference_space."""
+    preference_space = {}
+    transformed_preference_space = preference_space_transform(preference_space)
+    assert transformed_preference_space == {}
+
+
+def test_preference_space_transform_single_user_single_item():
+    """Test case 2: One user, one item."""
+    preference_space = {'user1': {'item1': 'rating1'}}
+    transformed_preference_space = preference_space_transform(preference_space)
+    assert transformed_preference_space == {'item1': {'user1': 'rating1'}}
+
+
+def test_preference_space_transform_multiple():
+    """Test case 3: Multiple users and items."""
+    preference_space = {
+        'userA': {'item1': 'ratingA1', 'item2': 'ratingA2'},
+        'userB': {'item1': 'ratingB1', 'item2': 'ratingB2'}
+    }
+    result = preference_space_transform(preference_space)
+    expected_result = {
+        'item1': {'userA': 'ratingA1', 'userB': 'ratingB1'},
+        'item2': {'userA': 'ratingA2', 'userB': 'ratingB2'}
+    }
+    assert result == expected_result

--- a/tests/test_user_match.py
+++ b/tests/test_user_match.py
@@ -1,0 +1,19 @@
+import pytest
+from recommender.similar_item import user_match
+
+
+def test_user_match_empty():
+    """Test case 1: Empty preference_space."""
+    preference_space = {}
+    person_to_recommend = 'userA'
+    result = user_match(preference_space, person_to_recommend)
+    print(result)
+    assert result == []
+
+
+def test_user_match_single_no_match():
+    """Test case 2: One user, no match."""
+    preference_space = {'userA': {'item1': 'ratingA1'}}
+    person_to_recommend = 'userA'
+    result = user_match(preference_space, person_to_recommend)
+    assert result == []


### PR DESCRIPTION
In this commit, I have create Unit Tests for all of the functions present in the recommender engine. This testing helps to create a more rigorous recommender engine by exposing the faults and helping the maintainers understand the library's scope and limitations.

These files use the pytest python testing utility. To run the testing suite, all you have to do is type pytest in the  recommender directory. Please note, you must have pytest installed which can be installed with [pip.](https://docs.pytest.org/en/7.1.x/getting-started.html)

Additionally, please note that I ran into some issues with importing the modules for the testing library. To overcome the issue and the run the tests, I have to rename the recommender_engine module to recommender.

Thanks for reviewing, please let me know if you have any additional questions!